### PR TITLE
Modularize "skip" option handling in `index.js`

### DIFF
--- a/config/constants.js
+++ b/config/constants.js
@@ -89,3 +89,9 @@ export const GITHUB_TOKEN = process.env.INPUT_TOKEN;
  * @type {string}
  */
 export const CHANGESET_PATH = process.env.INPUT_CHANGESET_PATH;
+
+/** 
+* The label that will be added to the PR if the "skip" option is used.
+* @type {string}
+*/
+export const SKIP_LABEL = "skip-changelog";


### PR DESCRIPTION
These changes move the logic for handling the "skip" option into `githubUtils.js` and reducing relevant code in `index.js` to a single line that calls on a `handleSkipOption` function. Also, the variables that will contain the extracted data from PRs are initialized outside of the `try-catch` block so that the values attached to these variables can be accessed by functions within either the `try` block or the `catch` block.