### PR TITLE
Fix error with destructuring variables from extractPullRequestData

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,8 +20,8 @@ async function run() {
   
   try {
     // Extract pull request data using the GitHub API
-    ({ owner, repo, prNumber, prDescription, prLink, branchRef }) =
-      await extractPullRequestData();
+    ({ owner, repo, prNumber, prDescription, prLink, branchRef } =
+      await extractPullRequestData());
     // Create an array of changelog entry strings from the PR description
     const changesetEntries = extractChangelogEntries(prDescription);
     // Create a map of changeset entries organized by category


### PR DESCRIPTION
This PR fixes an error in the destructuring assignment in `index.js` by surrounding the entire assignment, rather than just the variables, in parentheses.