### PR TITLE
Skip changelog parsing on autocut PRs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -24,6 +24,12 @@ const run = async () => {
     ))
       ? "manual"
       : "automatic";
+
+    const isAutocut = await isAutocut(octokit, prData);
+    if (isAutocut) {
+      return;
+    }
+
     const changesetEntriesMap = await handleChangelogEntriesParsing(
       octokit,
       prData,

--- a/src/utils/validators.utils.js
+++ b/src/utils/validators.utils.js
@@ -118,6 +118,30 @@ export const isGitHubAppNotInstalledOrSuspended = async (prData) => {
   return false;
 };
 
+/**
+ * Checks if the PR has the 'autocut' label.
+ * @param {InstanceType<typeof GitHub>} octokit - An Octokit instance.
+ * @param {Object} prData - An object containing the PR data.
+ * @returns {Promise<boolean>} - True if the PR has the 'autocut' label, false otherwise.
+ */
+export const isAutocut = async (octokit, prData) => {
+  try {
+    const { data: labels } = await octokit.rest.issues.listLabelsOnIssue({
+      owner: prData.baseOwner,
+      repo: prData.baseRepo,
+      issue_number: prData.prNumber,
+    });
+    const found = labels.some(label => label.name.toLowerCase() === 'autocut');
+    if (found) {
+      console.log("Detected 'autocut' label skipping changelog parsing process.");
+    }
+    return found;
+  } catch (error) {
+    console.error(`Error checking for 'autocut' label: ${error.message}`);
+    return false;
+  }
+};
+
 export const checkChangelogPrBridgeUrlDomainIsConfigured = () => {
   if (
     !CHANGELOG_PR_BRIDGE_URL_DOMAIN ||


### PR DESCRIPTION
Skips the changelog parsing process for autocut PRs as they will fail most of the time.

For example, here:
https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8195

The workflow will showed it failed which could cause maintainers to lax on reviewing the PR when glancing at it since it seems like it has a failure. Even though it was just a backport PR.